### PR TITLE
Supprime le patch d'inversion des boutons

### DIFF
--- a/patches/series
+++ b/patches/series
@@ -1,1 +1,1 @@
-wcs+invertpagebuttons.diff
+


### PR DESCRIPTION
Il est possible désormais de modifier l'ordre des boutons par une variable SCSS. Donc ceci sera fait pour le thème Loire-Atlantique.